### PR TITLE
feat: Added a basic card component

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,19 @@
+import { CardProps } from "@/data/cards";
+
+type Props = CardProps & {
+    isFlipped: boolean,
+    onClick: () => void,
+}
+
+const Card = ({id, pairId, backImage, frontImage, isMatched, isFlipped, alt, onClick}: Props) => {
+
+    return (
+        <div>
+            <button onClick={onClick}>
+                <img className="max-w-[100px] h-auto object-cover" src={isFlipped ? frontImage : backImage} alt={alt}/>
+            </button>
+        </div>
+    )
+}
+
+export default Card;

--- a/src/data/cards.tsx
+++ b/src/data/cards.tsx
@@ -1,10 +1,20 @@
-export const cards = [
+export type CardProps = {
+    id: number,
+    pairId: string,
+    frontImage: string,
+    backImage: string,
+    isMatched: boolean,
+    alt: string,
+}
+
+export const cards:CardProps[] = [
     {
         id: 1,
         pairId: "warrior1",
         frontImage: "/images/warrior.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Warrior Card"
     },
     {
         id: 2,
@@ -12,6 +22,7 @@ export const cards = [
         frontImage: "/images/warrior.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Warrior Card"
     },
     {
         id: 3,
@@ -19,6 +30,7 @@ export const cards = [
         frontImage: "/images/wizard.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Wizard Card"
     },
     {
         id: 4,
@@ -26,6 +38,7 @@ export const cards = [
         frontImage: "/images/wizard.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Wizard Card"
     },
     {
         id: 5,
@@ -33,6 +46,7 @@ export const cards = [
         frontImage: "/images/archer.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Archer Card"
     },
     {
         id: 6,
@@ -40,6 +54,7 @@ export const cards = [
         frontImage: "/images/archer.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Archer Card"
     },
      {
         id: 7,
@@ -47,6 +62,7 @@ export const cards = [
         frontImage: "/images/healingPotion.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Healing Potion Card"
     },
      {
         id: 8,
@@ -54,6 +70,7 @@ export const cards = [
         frontImage: "/images/healingPotion.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Healing Potion Card"
     },
          {
         id: 9,
@@ -61,6 +78,7 @@ export const cards = [
         frontImage: "/images/manaPotion.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Mana Potion Card"
     },
      {
         id: 10,
@@ -68,5 +86,6 @@ export const cards = [
         frontImage: "/images/manaPotion.png",
         backImage: "/images/unknown.png",
         isMatched: false,
+        alt: "Mana Potion Card"
     },
 ]


### PR DESCRIPTION
Added a basic card component which uses props to toggle between front, backimage.
<img width="1070" height="517" alt="image" src="https://github.com/user-attachments/assets/4df2ac8c-589b-4c20-928d-0df10f68b1eb" />
